### PR TITLE
avoid compiler warning -Wunused-but-set-variable with assertions disa…

### DIFF
--- a/src/n-acd-probe.c
+++ b/src/n-acd-probe.c
@@ -263,6 +263,7 @@ static void n_acd_probe_unlink(NAcdProbe *probe) {
         if (n_acd_probe_is_unique(probe)) {
                 r = n_acd_bpf_map_remove(probe->acd->fd_bpf_map, &probe->ip);
                 assert(r >= 0);
+                (void)r;
                 --probe->acd->n_bpf_map;
         }
         c_rbnode_unlink(&probe->ip_node);

--- a/src/test.h
+++ b/src/test.h
@@ -6,6 +6,8 @@
  * includes net-namespace setups, veth setups, and more.
  */
 
+#undef NDEBUG
+
 #include <assert.h>
 #include <endian.h>
 #include <errno.h>

--- a/src/util/test-timer.c
+++ b/src/util/test-timer.c
@@ -2,6 +2,8 @@
  * Tests for timer utility library
  */
 
+#undef NDEBUG
+
 #include <stdio.h>
 #include <errno.h>
 

--- a/src/util/timer.c
+++ b/src/util/timer.c
@@ -44,6 +44,7 @@ void timer_now(Timer *timer, uint64_t *nowp) {
 
         r = clock_gettime(timer->clock, &ts);
         assert(r >= 0);
+        (void)r;
 
         *nowp = ts.tv_sec * UINT64_C(1000000000) + ts.tv_nsec;
 }
@@ -74,6 +75,7 @@ void timer_rearm(Timer *timer) {
                                     },
                                     NULL);
                 assert(r >= 0);
+                (void)r;
 
                 timer->scheduled_timeout = time;
         }


### PR DESCRIPTION
…bled (NDEBUG)

With assertions disabled, we get compiler warnings:

  $ CFLAGS='-DNDEBUG -Wno-unused-parameter' meson build --warnlevel 2

    [1/10] Compiling C object 'src/25a6634@@nacd-private@sta/n-acd-probe.c.o'.
    ../src/n-acd-probe.c: In function ‘n_acd_probe_unlink’:
    ../src/n-acd-probe.c:257:13: warning: variable ‘r’ set but not used [-Wunused-but-set-variable]
             int r;
                 ^
    [2/10] Compiling C object 'src/25a6634@@nacd-private@sta/util_timer.c.o'.
    ../src/util/timer.c: In function ‘timer_now’:
    ../src/util/timer.c:43:13: warning: variable ‘r’ set but not used [-Wunused-but-set-variable]
             int r;
                 ^
    ../src/util/timer.c: In function ‘timer_rearm’:
    ../src/util/timer.c:54:13: warning: variable ‘r’ set but not used [-Wunused-but-set-variable]
             int r;
                 ^

Suppress them. Compiler warnings are cumbersome, because we want to
build with -Werror. Also, note that RPM's "%meson" macro by default sets
"-Db_ndebug=true" and thus NDEBUG.

For non-test code, silence the "-Wunused-but-set-variable" warnings by
casting the seemingly unused variable to (void).

For test code, undef NDEBUG. Clearly tests are not going to work if
assertions would be stripped out.


---

an alternative to casting to `(void)` be
```
#ifdef NDEBUG
#define _n_assert(x) do { if (0) { if (x) { } } } while (0)
#else
#define _n_assert(x) assert(x)
#endif
```
but then all uses of `assert()` would need to be replaced by our own assert macro. Which seemed not preferable. And it wouldn't solve the problem for tests, we we don't want to disable assertions.