### PR TITLE
n-acd: fix leaking socket handle in n_acd_socket_new() when setsockopt() fails

### DIFF
--- a/src/n-acd.c
+++ b/src/n-acd.c
@@ -127,8 +127,10 @@ static int n_acd_socket_new(int *fdp, int fd_bpf_prog, NAcdConfig *config) {
 
         if (fd_bpf_prog >= 0) {
                 r = setsockopt(s, SOL_SOCKET, SO_ATTACH_BPF, &fd_bpf_prog, sizeof(fd_bpf_prog));
-                if (r < 0)
-                        return -c_errno();
+                if (r < 0) {
+                        r = -c_errno();
+                        goto error;
+                }
         }
 
         r = bind(s, (struct sockaddr *)&address, sizeof(address));


### PR DESCRIPTION
Found by Coverity.