### PR TITLE
n-acd: fix handling of N_ACD_E_DROPPED

### DIFF
--- a/src/n-acd-probe.c
+++ b/src/n-acd-probe.c
@@ -420,7 +420,7 @@ int n_acd_probe_handle_timeout(NAcdProbe *probe) {
 
                         r = n_acd_send(probe->acd, &probe->ip, NULL);
                         if (r) {
-                                if (r != -N_ACD_E_DROPPED)
+                                if (r != N_ACD_E_DROPPED)
                                         return r;
 
                                 /*
@@ -475,7 +475,7 @@ int n_acd_probe_handle_timeout(NAcdProbe *probe) {
 
                 r = n_acd_send(probe->acd, &probe->ip, &probe->ip);
                 if (r) {
-                        if (r != -N_ACD_E_DROPPED)
+                        if (r != N_ACD_E_DROPPED)
                                 return r;
 
                         /*
@@ -595,7 +595,7 @@ int n_acd_probe_handle_packet(NAcdProbe *probe, struct ether_arp *packet, bool h
                         if (!rate_limited) {
                                 r = n_acd_send(probe->acd, &probe->ip, &probe->ip);
                                 if (r) {
-                                        if (r != -N_ACD_E_DROPPED)
+                                        if (r != N_ACD_E_DROPPED)
                                                 return r;
 
                                         if (probe->defend == N_ACD_DEFEND_ONCE) {
@@ -604,7 +604,7 @@ int n_acd_probe_handle_packet(NAcdProbe *probe, struct ether_arp *packet, bool h
                                         }
                                 }
 
-                                if (r != -N_ACD_E_DROPPED)
+                                if (r != N_ACD_E_DROPPED)
                                         probe->last_defend = now;
                         }
 


### PR DESCRIPTION
`N_ACD_E_DROPPED` is an error code of n-acd, albeit internal. But such codes are returned
as postive values, unlike error codes from errno.h (which are negative).

Fix comparing for `N_ACD_E_DROPPED`, otherwise the error gets propagate to the caller
when we should handle it internally.
