### PR TITLE
n-acd: use separate seed state for each probe of the same acd

### DIFF
--- a/src/n-acd-private.h
+++ b/src/n-acd-private.h
@@ -105,6 +105,7 @@ struct NAcdProbe {
         void *userdata;
 
         /* state */
+        unsigned int seed;
         unsigned int state;
         unsigned int n_iteration;
         unsigned int defend;

--- a/src/n-acd-probe.c
+++ b/src/n-acd-probe.c
@@ -172,7 +172,7 @@ static void n_acd_probe_schedule(NAcdProbe *probe, uint64_t n_timeout, unsigned 
         if (n_jitter) {
                 uint64_t random;
 
-                random = ((uint64_t)rand_r(&probe->acd->seed) << 32) | (uint64_t)rand_r(&probe->acd->seed);
+                random = ((uint64_t)rand_r(&probe->seed) << 32) | (uint64_t)rand_r(&probe->seed);
                 n_time += random % n_jitter;
         }
 
@@ -283,6 +283,7 @@ int n_acd_probe_new(NAcdProbe **probep, NAcd *acd, NAcdProbeConfig *config) {
         *probe = (NAcdProbe)N_ACD_PROBE_NULL(*probe);
         probe->acd = n_acd_ref(acd);
         probe->ip = config->ip;
+        probe->seed = acd->seed;
 
         /*
          * We use the provided timeout-length as multiplier for all our


### PR DESCRIPTION
Currently, all the probes of an acd instance share the same seed state. This means that the state is updated by all the probes, and as a consequence they get different jitters for the wait timeouts; therefore the order in which addresses become available (and can configured on the interface) is not deterministic.

Keep a separate seed state for each probe, initialized from the acd seed. This ensures that all the probes use the same timeouts when sending probe requests, and that in case of no collision, addresses are available in the order of probe start.

According to RFC 5227, the reason for the initial random delay is that

    This initial random delay helps ensure that a large number of
    hosts powered on at the same time do not all send their initial
    probe packets simultaneously

There is no mention that different addresses on the same interface should have a different delay.