### PR TITLE
build: drop --no-undefined

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -37,7 +37,6 @@ libnacd_shared = shared_library(
         soversion: 0,
         link_depends: libnacd_symfile,
         link_args: [
-                '-Wl,--no-undefined',
                 '-Wl,--version-script=@0@'.format(libnacd_symfile)
         ],
 )


### PR DESCRIPTION
to make it possible to build n-acd with clang and ASan.

-Wl,--no-undefined is still passed by meson by default unless -Db_lundef is set to false explicitly:
https://github.com/mesonbuild/meson/issues/764.

(it was spotted in the context of NetworkManager where n-acd is the last library where --no-undefined is still passed. It pins those deps though so it shouldn't affect it until it's bumped there)